### PR TITLE
VZ 8912: Use version to identify oci machine templates

### DIFF
--- a/ociocne/capi/capi.go
+++ b/ociocne/capi/capi.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/verrazzano/kontainer-engine-driver-ociocne/ociocne/gvr"
+	gvr "github.com/verrazzano/kontainer-engine-driver-ociocne/ociocne/gvr"
 	"github.com/verrazzano/kontainer-engine-driver-ociocne/ociocne/templates"
 	"github.com/verrazzano/kontainer-engine-driver-ociocne/ociocne/variables"
 	v1 "k8s.io/api/core/v1"
@@ -66,6 +66,10 @@ func createOrUpdateCAPISecret(ctx context.Context, v *variables.Variables, clien
 	return err
 }
 
+func UpdateClusterResources(ctx context.Context, dynamicInterface dynamic.Interface, v *variables.Variables) error {
+	return nil
+}
+
 // CreateOrUpdateAllObjects creates or updates all cluster objects
 func CreateOrUpdateAllObjects(ctx context.Context, kubernetesInterface kubernetes.Interface, dynamicInterface dynamic.Interface, v *variables.Variables) error {
 	if err := createOrUpdateCAPISecret(ctx, v, kubernetesInterface); err != nil {
@@ -82,8 +86,8 @@ func CreateOrUpdateAllObjects(ctx context.Context, kubernetesInterface kubernete
 // CreateOrUpdateNodeGroup creates or updates the worker node group replica count
 func CreateOrUpdateNodeGroup(ctx context.Context, client dynamic.Interface, v *variables.Variables) error {
 	return createOrUpdateObject(ctx, client, Object{
-		gvr.MachineDeployment,
-		templates.MachineDeployment,
+		GVR:  gvr.MachineDeployment,
+		Text: templates.MachineDeployment,
 	}, v)
 }
 
@@ -103,7 +107,7 @@ func cruObject(ctx context.Context, client dynamic.Interface, o Object, v *varia
 
 	if update {
 		// If the Object exists, merge toCreateObject with existingObject, and do an update
-		mergedObject := mergeUnstructured(existingObject, toCreateObject)
+		mergedObject := mergeUnstructured(existingObject, toCreateObject, o.LockedFields)
 		if err != nil {
 			return err
 		}

--- a/ociocne/capi/merge_test.go
+++ b/ociocne/capi/merge_test.go
@@ -10,10 +10,11 @@ import (
 
 func TestMerge(t *testing.T) {
 	var tests = []struct {
-		name string
-		m1   map[string]interface{}
-		m2   map[string]interface{}
-		res  map[string]interface{}
+		name         string
+		m1           map[string]interface{}
+		m2           map[string]interface{}
+		res          map[string]interface{}
+		lockedFields map[string]bool
 	}{
 		{
 			"merge two basic maps",
@@ -38,12 +39,41 @@ func TestMerge(t *testing.T) {
 					"x": "z",
 				},
 			},
+			nil,
+		},
+		{
+			"merge two basic maps with locked fields",
+			map[string]interface{}{
+				"a": "b",
+				"nest": map[string]interface{}{
+					"v": "w",
+					"x": "y",
+				},
+			},
+			map[string]interface{}{
+				"1": 2,
+				"nest": map[string]interface{}{
+					"x": "z",
+				},
+			},
+			map[string]interface{}{
+				"1": 2,
+				"a": "b",
+				"nest": map[string]interface{}{
+					"v": "w",
+					"x": "y",
+				},
+			},
+			map[string]bool{
+				"x": true,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := mergeMaps(tt.m1, tt.m2)
+
+			res := mergeMaps(tt.m1, tt.m2, tt.lockedFields)
 			assert.EqualValues(t, tt.res, res)
 		})
 	}

--- a/ociocne/capi/objects.go
+++ b/ociocne/capi/objects.go
@@ -31,37 +31,38 @@ func createObjects(v *variables.Variables) []Object {
 }
 
 type Object struct {
-	GVR  schema.GroupVersionResource
-	Text string
+	GVR          schema.GroupVersionResource
+	Text         string
+	LockedFields map[string]bool
 }
 
 var vpo = []Object{
-	{gvr.ConfigMap, templates.VPOConfigMap},
-	{gvr.ClusterResourceSet, templates.VPOResourceSet},
+	{GVR: gvr.ConfigMap, Text: templates.VPOConfigMap},
+	{GVR: gvr.ClusterResourceSet, Text: templates.VPOResourceSet},
 }
 
 var csi = []Object{
-	{gvr.ConfigMap, templates.CSIConfigMap},
-	{gvr.ClusterResourceSet, templates.CSIResourceSet},
+	{GVR: gvr.ConfigMap, Text: templates.CSIConfigMap},
+	{GVR: gvr.ClusterResourceSet, Text: templates.CSIResourceSet},
 }
 
 var ccm = []Object{
-	{gvr.ConfigMap, templates.CCMConfigMap},
-	{gvr.ClusterResourceSet, templates.CCMResourceSet},
+	{GVR: gvr.ConfigMap, Text: templates.CCMConfigMap},
+	{GVR: gvr.ClusterResourceSet, Text: templates.CCMResourceSet},
 }
 
 var cni = []Object{
-	{gvr.ConfigMap, templates.CalicoConfigMap},
-	{gvr.ClusterResourceSet, templates.CalicoResourceSet},
+	{GVR: gvr.ConfigMap, Text: templates.CalicoConfigMap},
+	{GVR: gvr.ClusterResourceSet, Text: templates.CalicoResourceSet},
 }
 
 var capi = []Object{
-	{gvr.Cluster, templates.Cluster},
-	{gvr.ClusterIdentity, templates.ClusterIdentity},
-	{gvr.OCICluster, templates.OCICluster},
-	{gvr.KubeadmConfigTemplate, templates.OCNEConfigTemplate},
-	{gvr.KubeadmControlPlane, templates.OCNEControlPlane},
-	{gvr.MachineDeployment, templates.MachineDeployment},
-	{gvr.OCIMachineTemplate, templates.OCIMachineTemplate},
-	{gvr.OCIMachineTemplate, templates.OCIControlPlaneMachineTemplate},
+	{GVR: gvr.Cluster, Text: templates.Cluster},
+	{GVR: gvr.ClusterIdentity, Text: templates.ClusterIdentity},
+	{GVR: gvr.OCICluster, Text: templates.OCICluster},
+	{GVR: gvr.OCNEConfigTemplate, Text: templates.OCNEConfigTemplate},
+	{GVR: gvr.OCNEControlPlane, Text: templates.OCNEControlPlane},
+	{GVR: gvr.MachineDeployment, Text: templates.MachineDeployment},
+	{GVR: gvr.OCIMachineTemplate, Text: templates.OCIMachineTemplate},
+	{GVR: gvr.OCIMachineTemplate, Text: templates.OCIControlPlaneMachineTemplate},
 }

--- a/ociocne/capi/upgrade.go
+++ b/ociocne/capi/upgrade.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package capi
+
+import (
+	"context"
+	"github.com/verrazzano/kontainer-engine-driver-ociocne/ociocne/variables"
+	"k8s.io/client-go/dynamic"
+)
+
+func UpgradeClusterVersion(ctx context.Context, di dynamic.Interface, v *variables.Variables, version string) error {
+	return nil
+}

--- a/ociocne/gvr/gvr.go
+++ b/ociocne/gvr/gvr.go
@@ -44,7 +44,7 @@ var Machine = schema.GroupVersionResource{
 	Resource: "machines",
 }
 
-var KubeadmControlPlane = schema.GroupVersionResource{
+var OCNEControlPlane = schema.GroupVersionResource{
 	Group:    ControlPlaneXK8sIO,
 	Version:  V1Beta1Version,
 	Resource: "ocnecontrolplanes",
@@ -56,7 +56,7 @@ var OCIMachineTemplate = schema.GroupVersionResource{
 	Resource: "ocimachinetemplates",
 }
 
-var KubeadmConfigTemplate = schema.GroupVersionResource{
+var OCNEConfigTemplate = schema.GroupVersionResource{
 	Group:    "bootstrap.cluster.x-k8s.io",
 	Version:  "v1beta1",
 	Resource: "ocneconfigtemplates",

--- a/ociocne/k8s/client.go
+++ b/ociocne/k8s/client.go
@@ -16,6 +16,11 @@ const (
 	injectedKubeConfig = "INJECTED_KUBECONFIG"
 )
 
+var (
+	kubernetesInterface kubernetes.Interface
+	dynamicInterface    dynamic.Interface
+)
+
 // MustSetKubeconfigFromEnv sets the current kubeconfig from the environment. If the kubeconfig cannot be set, panic.
 func MustSetKubeconfigFromEnv() {
 	val := os.Getenv(injectedKubeConfig)
@@ -53,10 +58,27 @@ func NewDynamicForKubeconfig(kubeconfig []byte) (dynamic.Interface, error) {
 
 // InjectedInterface creates a new kubernetes.Interface using the injected kubeconfig
 func InjectedInterface() (kubernetes.Interface, error) {
-	return NewInterfaceForKubeconfig(InjectedKubeConfig)
+	if kubernetesInterface != nil {
+		return kubernetesInterface, nil
+	}
+	ki, err := NewInterfaceForKubeconfig(InjectedKubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	kubernetesInterface = ki
+	return kubernetesInterface, nil
+
 }
 
 // InjectedDynamic creates a new dynamic.Interface using the injected kubeconfig
 func InjectedDynamic() (dynamic.Interface, error) {
-	return NewDynamicForKubeconfig(InjectedKubeConfig)
+	if dynamicInterface != nil {
+		return dynamicInterface, nil
+	}
+	di, err := NewDynamicForKubeconfig(InjectedKubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	dynamicInterface = di
+	return dynamicInterface, nil
 }

--- a/ociocne/templates/machinedeployment.goyaml
+++ b/ociocne/templates/machinedeployment.goyaml
@@ -22,5 +22,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OCIMachineTemplate
-        name:  {{.Name}}-md-0
+        name:  {{.Name}}-{{.SanitizedK8sVersion}}-md-0
       version: {{.KubernetesVersion}}

--- a/ociocne/templates/ocicontrolplanemachinetemplate.goyaml
+++ b/ociocne/templates/ocicontrolplanemachinetemplate.goyaml
@@ -4,7 +4,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
 metadata:
-  name:  {{.Name}}-control-plane
+  name:  {{.Name}}-{{.SanitizedK8sVersion}}-control-plane
   namespace: {{.Namespace}}
 spec:
   template:

--- a/ociocne/templates/ocimachinetemplate.goyaml
+++ b/ociocne/templates/ocimachinetemplate.goyaml
@@ -4,7 +4,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
 metadata:
-  name:  {{.Name}}-md-0
+  name:  {{.Name}}-{{.SanitizedK8sVersion}}-md-0
   namespace: {{.Namespace}}
 spec:
   template:

--- a/ociocne/templates/ocnecontrolplane.goyaml
+++ b/ociocne/templates/ocnecontrolplane.goyaml
@@ -11,7 +11,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OCIMachineTemplate
-      name: {{.Name}}-control-plane
+      name: {{.Name}}-{{.SanitizedK8sVersion}}-control-plane
       namespace: {{.Namespace}}
   replicas: {{.ControlPlaneReplicas}}
   version: {{.KubernetesVersion}}

--- a/ociocne/variables/variables_test.go
+++ b/ociocne/variables/variables_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package variables
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSanitizeVersion(t *testing.T) {
+	var tests = []struct {
+		input  string
+		output string
+	}{
+		{
+			"1-2-4",
+			"1-2-4",
+		},
+		{
+			"v1.25.8",
+			"v1-25-8",
+		},
+		{
+			"v1.24.11+el1",
+			"v1-24-11-el1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Replace %s", tt.input), func(t *testing.T) {
+			assert.Equal(t, tt.output, sanitizeK8sVersion(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
Using kubernetes version in the oci machine template will facilitate kubernetes version upgrades, which require new oci machine templates.