### PR TITLE
VZ 8910: Cluster updates

### DIFF
--- a/ociocne/capi/capi.go
+++ b/ociocne/capi/capi.go
@@ -67,24 +67,12 @@ func createOrUpdateCAPISecret(ctx context.Context, v *variables.Variables, clien
 	return err
 }
 
-func UpdateClusterResources(ctx context.Context, dynamicInterface dynamic.Interface, v *variables.Variables) error {
-	return nil
-}
-
 // CreateOrUpdateAllObjects creates or updates all cluster objects
 func CreateOrUpdateAllObjects(ctx context.Context, kubernetesInterface kubernetes.Interface, dynamicInterface dynamic.Interface, v *variables.Variables) error {
 	if err := createOrUpdateCAPISecret(ctx, v, kubernetesInterface); err != nil {
 		return fmt.Errorf("failed to create CAPI credentials: %v", err)
 	}
 	return createOrUpdateObjects(ctx, dynamicInterface, object.CreateObjects(v), v)
-}
-
-// CreateOrUpdateNodeGroup creates or updates the worker node group replica count
-func CreateOrUpdateNodeGroup(ctx context.Context, client dynamic.Interface, v *variables.Variables) error {
-	return createOrUpdateObject(ctx, client, object.Object{
-		GVR:  gvr.MachineDeployment,
-		Text: templates.MachineDeployment,
-	}, v)
 }
 
 func createOrUpdateObjects(ctx context.Context, dynamicInterface dynamic.Interface, objects []object.Object, v *variables.Variables) error {

--- a/ociocne/capi/object/objects.go
+++ b/ociocne/capi/object/objects.go
@@ -11,6 +11,22 @@ import (
 )
 
 func CreateObjects(v *variables.Variables) []Object {
+	return objectList(v, include{
+		workers:      true,
+		controlplane: true,
+		capi:         true,
+	})
+}
+
+func UpdateObjects(v *variables.Variables) []Object {
+	return objectList(v, include{
+		workers:      false,
+		controlplane: false,
+		capi:         true,
+	})
+}
+
+func objectList(v *variables.Variables, i include) []Object {
 	var res []Object
 
 	// Create addons if they are enabled
@@ -26,9 +42,15 @@ func CreateObjects(v *variables.Variables) []Object {
 	if v.InstallVerrazzano {
 		res = append(res, vpo...)
 	}
-	res = append(res, capi...)
-	res = append(res, ControlPlane...)
-	res = append(res, Workers...)
+	if i.capi {
+		res = append(res, capi...)
+	}
+	if i.controlplane {
+		res = append(res, ControlPlane...)
+	}
+	if i.workers {
+		res = append(res, Workers...)
+	}
 	return res
 }
 
@@ -36,6 +58,12 @@ type Object struct {
 	GVR          schema.GroupVersionResource
 	Text         string
 	LockedFields map[string]bool
+}
+
+type include struct {
+	workers      bool
+	controlplane bool
+	capi         bool
 }
 
 var vpo = []Object{

--- a/ociocne/capi/upgrade.go
+++ b/ociocne/capi/upgrade.go
@@ -9,17 +9,39 @@ import (
 	"github.com/verrazzano/kontainer-engine-driver-ociocne/ociocne/capi/object"
 	"github.com/verrazzano/kontainer-engine-driver-ociocne/ociocne/variables"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
 
-func UpgradeClusterVersion(ctx context.Context, di dynamic.Interface, v *variables.Variables) error {
+// UpdateCluster upgrades the CAPI cluster by going through the following stages:
+// 1. update the CAPI credentials using the cloud credential. This keeps the cloud credential up-to-date
+// 2. update the control plane, and then wait for the control plane to be ready
+// 3. update the worker nodes, and then wait for the worker nodes to be ready
+// 4. update the remaining cluster resources, and then wait for the cluster to be ready
+func UpdateCluster(ctx context.Context, ki kubernetes.Interface, di dynamic.Interface, v *variables.Variables) error {
+	// update the CAPI credentials if necessary
+	if err := createOrUpdateCAPISecret(ctx, v, ki); err != nil {
+		return fmt.Errorf("failed to create CAPI credentials: %v", err)
+	}
+
+	// update the control plane nodes
 	if err := createOrUpdateObjects(ctx, di, object.ControlPlane, v); err != nil {
-		return fmt.Errorf("error updating control plane kubernetes version: %v", err)
+		return fmt.Errorf("error updating control plane: %v", err)
 	}
 	if err := WaitForCAPIClusterReady(ctx, di, v); err != nil {
 		return err
 	}
+
+	// update the worker nodes
 	if err := createOrUpdateObjects(ctx, di, object.Workers, v); err != nil {
-		return fmt.Errorf("error updating worker kubernetes version: %v", err)
+		return fmt.Errorf("error updating workers: %v", err)
+	}
+	if err := WaitForCAPIClusterReady(ctx, di, v); err != nil {
+		return err
+	}
+
+	// update the remaining capi resources
+	if err := createOrUpdateObjects(ctx, di, object.UpdateObjects(v), v); err != nil {
+		return fmt.Errorf("error updating cluster resources: %v", err)
 	}
 	return WaitForCAPIClusterReady(ctx, di, v)
 }

--- a/ociocne/templates/machinedeployment.goyaml
+++ b/ociocne/templates/machinedeployment.goyaml
@@ -22,5 +22,5 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OCIMachineTemplate
-        name:  {{.Name}}-{{.SanitizedK8sVersion}}-md-0
+        name:  {{.Name}}-{{.Hash}}-md-0
       version: {{.KubernetesVersion}}

--- a/ociocne/templates/ocicontrolplanemachinetemplate.goyaml
+++ b/ociocne/templates/ocicontrolplanemachinetemplate.goyaml
@@ -4,7 +4,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
 metadata:
-  name:  {{.Name}}-{{.SanitizedK8sVersion}}-control-plane
+  name:  {{.Name}}-{{.Hash}}-control-plane
   namespace: {{.Namespace}}
 spec:
   template:

--- a/ociocne/templates/ocimachinetemplate.goyaml
+++ b/ociocne/templates/ocimachinetemplate.goyaml
@@ -4,7 +4,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
 metadata:
-  name:  {{.Name}}-{{.SanitizedK8sVersion}}-md-0
+  name:  {{.Name}}-{{.Hash}}-md-0
   namespace: {{.Namespace}}
 spec:
   template:

--- a/ociocne/templates/ocnecontrolplane.goyaml
+++ b/ociocne/templates/ocnecontrolplane.goyaml
@@ -11,7 +11,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OCIMachineTemplate
-      name: {{.Name}}-{{.SanitizedK8sVersion}}-control-plane
+      name: {{.Name}}-{{.Hash}}-control-plane
       namespace: {{.Namespace}}
   replicas: {{.ControlPlaneReplicas}}
   version: {{.KubernetesVersion}}

--- a/ociocne/variables/variables.go
+++ b/ociocne/variables/variables.go
@@ -212,10 +212,16 @@ func (v *Variables) IsKubernetesUpgrade(vNew *Variables) bool {
 	return v.KubernetesVersion != vNew.KubernetesVersion
 }
 
-func (v *Variables) SetUpdateValues(vNew *Variables) error {
+func (v *Variables) SetUpdateValues(ctx context.Context, vNew *Variables) error {
 	v.KubernetesVersion = vNew.KubernetesVersion
 	v.SanitizedK8sVersion = sanitizeK8sVersion(vNew.KubernetesVersion)
-	return v.SetVersionMapping()
+	if err := v.SetVersionMapping(); err != nil {
+		return err
+	}
+	v.NodeReplicas = vNew.NodeReplicas
+	v.ControlPlaneReplicas = vNew.ControlPlaneReplicas
+	v.DisplayName = vNew.DisplayName
+	return v.SetDynamicValues(ctx)
 }
 
 // SetDynamicValues sets dynamic values from OCI in the Variables


### PR DESCRIPTION
Support updates for clusters. Updates occur in this manner:
1. update the control plane
2. update the worker nodes
3. update the remaining cluster resources

between each step, the driver ensures the cluster is "Ready" before continuing: All machines are ready and the cluster reports ready.