### PR TITLE
VZ-10217:  Create an indicator of driver that created cluster on workload cluster

### DIFF
--- a/pkg/capi/verrazzano.go
+++ b/pkg/capi/verrazzano.go
@@ -58,6 +58,16 @@ func (c *CAPIClient) InstallAndRegisterVerrazzano(ctx context.Context, ki kubern
 	return nil
 }
 
+func (c *CAPIClient) CreateClusterProvisionerConfigMap(ctx context.Context, adminDi dynamic.Interface, v *variables.Variables) error {
+	// Create the provisioner config map Resource
+	if _, err := createOrUpdateObject(ctx, adminDi, object.Object{
+		Text: templates.ProvisionerCM,
+	}, v); err != nil {
+		return fmt.Errorf("provisioner configmap creation error: %v", err)
+	}
+	return nil
+}
+
 // DeleteVerrazzanoResources deletes the Verrazzano resource on the managed cluster, and the VerrazzanoManagedCluster on the admin cluster
 func (c *CAPIClient) DeleteVerrazzanoResources(ctx context.Context, managedDi, adminDi dynamic.Interface, v *variables.Variables) error {
 	if !v.InstallVerrazzano {

--- a/pkg/ocne_driver.go
+++ b/pkg/ocne_driver.go
@@ -598,8 +598,8 @@ func (d *OCIOCNEDriver) PostCheck(ctx context.Context, info *types.ClusterInfo) 
 		return info, fmt.Errorf("failed to install modules on managed cluster %s: %v", state.Name, err)
 	}
 
-	if err := capiClient.InstallModules(ctx, managedKI, managedDI, state); err != nil {
-		return info, fmt.Errorf("failed to install modules on managed cluster %s: %v", state.Name, err)
+	if err := capiClient.CreateClusterProvisionerConfigMap(ctx, managedDI, state); err != nil {
+		return info, fmt.Errorf("failed to create provisioner config map on managed cluster %s: %v", state.Name, err)
 	}
 
 	d.Logger.Infof("Installing Verrazzano on cluster %v", state.Name)

--- a/pkg/templates/provisioner.goyaml
+++ b/pkg/templates/provisioner.goyaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: cluster-provisioner
+    namespace: default
+data:
+    driver: ociocne

--- a/pkg/templates/tmpl.go
+++ b/pkg/templates/tmpl.go
@@ -49,3 +49,6 @@ var CalicoModule string
 
 //go:embed vmc.goyaml
 var VMC string
+
+//go:embed provisioner.goyaml
+var ProvisionerCM string


### PR DESCRIPTION
Creates a config map on the cluster that provides an indication that the cluster was created by the OCNE driver.  Currently use to prevent the deletion of the cattle-system namespace (and associated cluster agent) during VZ uninstallation.